### PR TITLE
refactor db, dbType -> DbBox

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -36,11 +36,11 @@ INSERT INTO migrations_lock SET ` + "`index`" + ` = 1, is_locked = 0;`,
 )
 
 func CommandInit(cfg config.MigConfig) error {
-	db, dbType := database.Connect(cfg.Connection)
+	dbox := database.Connect(cfg.Connection)
 
-	defer db.Close()
+	defer dbox.Db.Close()
 
-	_, err := db.Exec(INIT.For(dbType))
+	_, err := dbox.Exec(INIT)
 
 	if err != nil {
 		color.Red("error initializing mig!", err)

--- a/commands/list.go
+++ b/commands/list.go
@@ -10,10 +10,10 @@ import (
 )
 
 func CommandList(cfg config.MigConfig) error {
-	db, _ := database.Connect(cfg.Connection)
-	defer db.Close()
+	dbox := database.Connect(cfg.Connection)
+	defer dbox.Db.Close()
 
-	status, err := migrations.GetStatus(cfg, db, true)
+	status, err := migrations.GetStatus(cfg, dbox, true)
 
 	if err != nil {
 		return err

--- a/commands/locks.go
+++ b/commands/locks.go
@@ -24,11 +24,11 @@ COMMIT;`,
 )
 
 func CommandLock(cfg config.MigConfig) error {
-	db, dbType := database.Connect(cfg.Connection)
-	defer db.Close()
+	dbox := database.Connect(cfg.Connection)
+	defer dbox.Db.Close()
 
 	var was_locked int
-	err := db.QueryRow(LOCK.For(dbType)).Scan(&was_locked)
+	err := dbox.QueryRow(LOCK).Scan(&was_locked)
 
 	if err != nil {
 		color.Red("mig: unable to lock!", err)
@@ -46,11 +46,11 @@ func CommandLock(cfg config.MigConfig) error {
 }
 
 func CommandUnlock(cfg config.MigConfig) error {
-	db, dbType := database.Connect(cfg.Connection)
-	defer db.Close()
+	dbox := database.Connect(cfg.Connection)
+	defer dbox.Db.Close()
 
 	var was_locked int
-	err := db.QueryRow(UNLOCK.For(dbType)).Scan(&was_locked)
+	err := dbox.QueryRow(UNLOCK).Scan(&was_locked)
 
 	if err != nil {
 		color.Red("mig: unable to unlock!", err)

--- a/commands/status.go
+++ b/commands/status.go
@@ -58,13 +58,13 @@ func CommandStatus(cfg config.MigConfig) error {
 
 	// Attempt to connect to database
 
-	db, dbType := database.Connect(cfg.Connection)
+	dbox := database.Connect(cfg.Connection)
 
 	// Check if migration tables exist
 
 	existMigrations := false
 
-	err := db.QueryRow(EXIST_MIGRATIONS.For(dbType)).Scan(&existMigrations)
+	err := dbox.QueryRow(EXIST_MIGRATIONS).Scan(&existMigrations)
 
 	if err != nil {
 		color.Red("unable to tell if 'migrations' table exists!")
@@ -74,7 +74,7 @@ func CommandStatus(cfg config.MigConfig) error {
 
 	existLock := false
 
-	err = db.QueryRow(EXIST_LOCK.For(dbType)).Scan(&existLock)
+	err = dbox.QueryRow(EXIST_LOCK).Scan(&existLock)
 
 	if err != nil {
 		color.Red("unable to tell if 'migrations_lock' table exists!\n")
@@ -112,11 +112,11 @@ func CommandStatus(cfg config.MigConfig) error {
 		return nil
 	}
 
-	if dbType == "mysql" {
+	if dbox.Type == "mysql" {
 		// The following gnarly comparison checks need to be rebuilt first
 		color.Yellow("migration table description check is currently unimplemented for mysql.\n")
 	} else {
-		rows, err := db.Query(DESCRIBE.For(dbType))
+		rows, err := dbox.Query(DESCRIBE)
 
 		if err != nil {
 			color.Red("unable to describe the migration tables!\n")
@@ -175,7 +175,7 @@ func CommandStatus(cfg config.MigConfig) error {
 	// Check if locked
 
 	locked := false
-	err = db.QueryRow(LOCK_STATUS.For(dbType)).Scan(&locked)
+	err = dbox.QueryRow(LOCK_STATUS).Scan(&locked)
 
 	if err != nil {
 		color.Red("unable to determine lock status!\n")
@@ -195,7 +195,7 @@ func CommandStatus(cfg config.MigConfig) error {
 
 	// Display the name of the last run migration
 
-	status, err := migrations.GetStatus(cfg, db, false)
+	status, err := migrations.GetStatus(cfg, dbox, false)
 
 	if err != nil {
 		color.Red("unable to determine migration status!")

--- a/commands/up.go
+++ b/commands/up.go
@@ -21,11 +21,11 @@ var (
 )
 
 func CommandUp(cfg config.MigConfig) error {
-	db, dbType := database.Connect(cfg.Connection)
+	dbox := database.Connect(cfg.Connection)
 
-	defer db.Close()
+	defer dbox.Db.Close()
 
-	status, err := migrations.GetStatus(cfg, db, false)
+	status, err := migrations.GetStatus(cfg, dbox, false)
 
 	if err != nil {
 		color.Red("Encountered an error trying to get migrations status!\n")
@@ -55,7 +55,7 @@ func CommandUp(cfg config.MigConfig) error {
 		return err
 	}
 
-	locked, err := database.ObtainLock(db, dbType)
+	locked, err := database.ObtainLock(dbox)
 
 	if err != nil {
 		color.Red("Error obtaining lock for migration!\n")
@@ -71,12 +71,12 @@ func CommandUp(cfg config.MigConfig) error {
 	var query string
 
 	if queries.UpTx {
-		query = BEGIN.For(dbType) + queries.Up + END.For(dbType)
+		query = BEGIN.For(dbox.Type) + queries.Up + END.For(dbox.Type)
 	} else {
 		query = queries.Up
 	}
 
-	_, err = db.Exec(query)
+	_, err = dbox.Db.Exec(query)
 
 	if err != nil {
 		color.Red("Encountered an error while running migration!\n")
@@ -86,7 +86,7 @@ func CommandUp(cfg config.MigConfig) error {
 
 	color.Green("Migration %s was successfully applied!\n", next)
 
-	err = migrations.AddMigration(db, next, dbType)
+	err = migrations.AddMigration(dbox, next)
 
 	if err != nil {
 		color.Red("The migration query executed but unable to track it in the migrations table!\n")
@@ -95,7 +95,7 @@ func CommandUp(cfg config.MigConfig) error {
 		return err
 	}
 
-	released, err := database.ReleaseLock(db, dbType)
+	released, err := database.ReleaseLock(dbox)
 
 	if err != nil {
 		color.Red("Error obtaining lock for migration!\n")

--- a/database/locking.go
+++ b/database/locking.go
@@ -1,7 +1,5 @@
 package database
 
-import "database/sql"
-
 var (
 	OBTAIN = QueryBox{
 		Postgres: `UPDATE migrations_lock SET is_locked = 1 WHERE index = 1 AND is_locked = 0;`,
@@ -13,8 +11,8 @@ var (
 	}
 )
 
-func ObtainLock(db *sql.DB, dbType string) (bool, error) {
-	result, err := db.Exec(OBTAIN.For(dbType))
+func ObtainLock(dbox DbBox) (bool, error) {
+	result, err := dbox.Exec(OBTAIN)
 
 	if err != nil {
 		return false, err
@@ -29,8 +27,8 @@ func ObtainLock(db *sql.DB, dbType string) (bool, error) {
 	return affected == 1, nil
 }
 
-func ReleaseLock(db *sql.DB, dbType string) (bool, error) {
-	result, err := db.Exec(RELEASE.For(dbType))
+func ReleaseLock(dbox DbBox) (bool, error) {
+	result, err := dbox.Exec(RELEASE)
 
 	if err != nil {
 		return false, err

--- a/migrations/listrows.go
+++ b/migrations/listrows.go
@@ -1,12 +1,15 @@
 package migrations
 
 import (
-	"database/sql"
 	"time"
+
+	"github.com/tlhunter/mig/database"
 )
 
-// TODO: QueryBox, refactor 'db' everywhere to be a struct holding db and dbType
-const LIST = `SELECT id, name, batch, migration_time FROM migrations ORDER BY id ASC;`
+var LIST = database.QueryBox{
+	Postgres: `SELECT id, name, batch, migration_time FROM migrations ORDER BY id ASC;`,
+	Mysql:    `SELECT id, name, batch, migration_time FROM migrations ORDER BY id ASC;`,
+}
 
 type MigrationRow struct {
 	Id    int
@@ -15,10 +18,10 @@ type MigrationRow struct {
 	Time  time.Time
 }
 
-func ListRows(db *sql.DB) ([]MigrationRow, error) {
+func ListRows(dbox database.DbBox) ([]MigrationRow, error) {
 	var migRows []MigrationRow
 
-	rows, err := db.Query(LIST)
+	rows, err := dbox.Query(LIST)
 
 	if err != nil {
 		return migRows, err

--- a/migrations/status.go
+++ b/migrations/status.go
@@ -1,11 +1,11 @@
 package migrations
 
 import (
-	"database/sql"
 	"time"
 
 	"github.com/fatih/color"
 	"github.com/tlhunter/mig/config"
+	"github.com/tlhunter/mig/database"
 )
 
 type MigrationStatus struct {
@@ -20,7 +20,7 @@ type MigrationStatus struct {
 // TODO: This shouldn't print anything at all but should instead return an array of migration data
 // Printing and color constants should be in the CommandList function
 
-func GetStatus(cfg config.MigConfig, db *sql.DB, print bool) (MigrationStatus, error) {
+func GetStatus(cfg config.MigConfig, dbox database.DbBox, print bool) (MigrationStatus, error) {
 	var status MigrationStatus
 
 	migFiles, err := ListFiles(cfg.Migrations)
@@ -29,7 +29,7 @@ func GetStatus(cfg config.MigConfig, db *sql.DB, print bool) (MigrationStatus, e
 		return status, err
 	}
 
-	migRows, err := ListRows(db)
+	migRows, err := ListRows(dbox)
 
 	if err != nil {
 		return status, err


### PR DESCRIPTION
- not sure if this is idiomatic?
- might be heavy handed? like, would most people working on a codebase prefer `*sql.DB` references?
- the DbBox methods basically forward to a `*sql.DB` instance with syntactic sugar
  - any way to also forward the doc / autocomplete?

```go
// without convenience methods
	err := dbox.QueryRow(UNLOCK).Scan(&was_locked)
// with convenience methods
	err := dbox.Db.QueryRow(UNLOCK.For(dbType)).Scan(&was_locked)
```