### PR TITLE
--json

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ mig status --file="prod.migrc"
 mig --file="local.migrc" down
 ```
 
+### JSON Output
+
+Provide the flag `--json` and `mig` will output a single line valid JSON document.
+
+```sh
+mig version --json
+```
+
 
 ## Commands
 

--- a/commands/all.go
+++ b/commands/all.go
@@ -1,20 +1,24 @@
 package commands
 
 import (
-	"errors"
-
 	"github.com/fatih/color"
 
 	"github.com/tlhunter/mig/config"
 	"github.com/tlhunter/mig/database"
 	"github.com/tlhunter/mig/migrations"
+	"github.com/tlhunter/mig/result"
 )
 
-func CommandAll(cfg config.MigConfig) error {
+type CommandUpFamilyResult struct {
+	MigrationBatch int                        `json:"batch"`
+	Migrations     *[]migrations.MigrationRow `json:"migrations"`
+}
+
+func CommandAll(cfg config.MigConfig) result.Response {
 	dbox, err := database.Connect(cfg.Connection)
 
 	if err != nil {
-		return err
+		return *result.NewErrorWithDetails("database connection error", "db_conn", err)
 	}
 
 	defer dbox.Db.Close()
@@ -23,32 +27,36 @@ func CommandAll(cfg config.MigConfig) error {
 	status, err := migrations.GetStatus(cfg, dbox)
 
 	if err != nil {
-		return errors.New("Encountered an error trying to get migrations status!")
+		return *result.NewErrorWithDetails("Encountered an error trying to get migrations status!", "retrieve_status", err)
 	}
 
 	if status.Skipped > 0 {
-		return errors.New("Refusing to run with skipped migrations! Run `mig status` for details.")
+		return *result.NewError("Refusing to run with skipped migrations! Run `mig status` for details.", "abort_skipped_migrations")
 	}
 
 	if status.Next == "" {
-		return errors.New("There are no migrations to run.")
+		return *result.NewError("There are no migrations to run.", "no_migrations")
 	}
 
 	locked, err := database.ObtainLock(dbox)
 
 	if err != nil {
-		color.Red("Error obtaining lock for running migrations!")
-		return err
+		return *result.NewErrorWithDetails("Error obtaining lock for migration!", "obtain_lock", err)
 	}
 
 	if !locked {
-		return errors.New("Unable to obtain lock for running migrations!")
+		return *result.NewError("Unable to obtain lock for migration!", "obtain_lock")
 	}
 
 	highest, err := migrations.GetHighestValues(dbox)
 	batchId := highest.Batch
 
-	color.HiWhite("Running migrations for batch %d...", batchId)
+	var executedMigrations []migrations.MigrationRow
+
+	res := result.NewSerializable(color.HiWhiteString("Running migrations for batch %d...", batchId), CommandUpFamilyResult{
+		MigrationBatch: batchId,
+		Migrations:     &executedMigrations,
+	})
 
 	for {
 		status, err := migrations.GetStatus(cfg, dbox)
@@ -64,8 +72,7 @@ func CommandAll(cfg config.MigConfig) error {
 		queries, err := migrations.GetQueriesFromFile(filename)
 
 		if err != nil {
-			color.Red("Error attempting to read next migration file!")
-			return err
+			return *result.NewErrorWithDetails("Error attempting to read next migration file!", "read_next_migration", err)
 		}
 
 		var query string
@@ -79,32 +86,33 @@ func CommandAll(cfg config.MigConfig) error {
 		_, err = dbox.Db.Exec(query)
 
 		if err != nil {
-			color.Red("Encountered an error while running migration!")
-			return err
+			return *result.NewErrorWithDetails("Encountered an error while running migration!", "migration_failed", err)
 		}
 
-		color.Green("Migration %s was successfully applied!", next)
+		res.AddSuccessLn(color.GreenString("Migration %s was successfully applied!", next))
 
-		err = migrations.AddMigrationWithBatch(dbox, next, batchId)
+		migration, err := migrations.AddMigrationWithBatch(dbox, next, batchId)
 
 		if err != nil {
-			color.Red("The migration query executed but unable to track it in the migrations table!")
-			color.White("You may want to manually add it and investigate the error.")
-			color.White("Any remaining migrations will not be executed!")
-			return err
+			res.SetError("The migration query executed but unable to track it in the migrations table!", "untracked_migration")
+			res.AddErrorLn("You may want to manually add it and investigate the error.")
+			res.AddErrorLn("Any remaining migrations will not be executed!")
+			return *res
 		}
+
+		executedMigrations = append(executedMigrations, migration)
 	}
 
 	released, err := database.ReleaseLock(dbox)
 
 	if err != nil {
-		color.Red("Error releasing lock for migration!")
-		return err
+		res.SetError("Error releasing lock after running migration!", "release_lock")
+		return *res
 	}
 
 	if !released {
-		return errors.New("Unable to release lock for migration!")
+		res.SetError("Unable to release lock after running migration!", "release_lock")
 	}
 
-	return nil
+	return *res
 }

--- a/commands/all.go
+++ b/commands/all.go
@@ -95,6 +95,7 @@ func CommandAll(cfg config.MigConfig) result.Response {
 
 		if err != nil {
 			res.SetError("The migration query executed but unable to track it in the migrations table!", "untracked_migration")
+			res.SetErrorDetails(err)
 			res.AddErrorLn("You may want to manually add it and investigate the error.")
 			res.AddErrorLn("Any remaining migrations will not be executed!")
 			return *res

--- a/commands/dispatch.go
+++ b/commands/dispatch.go
@@ -1,66 +1,66 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/tlhunter/mig/config"
+	"github.com/tlhunter/mig/result"
 )
 
-func Dispatch(cfg config.MigConfig, subcommands []string) error {
-	var err error
+func Dispatch(cfg config.MigConfig, subcommands []string) result.Response {
+	var res result.Response
 	if len(subcommands) == 0 {
-		err = errors.New("usage: mig <command>")
+		res.SetError("usage: mig <command>", "command_usage")
 	}
 
 	switch subcommands[0] {
 	case "create":
 		if len(subcommands) >= 2 {
-			err = CommandCreate(cfg, subcommands[1])
+			res = CommandCreate(cfg, subcommands[1])
 		} else {
-			err = errors.New("usage: mig create \"<migration name>\"")
+			res.SetError("usage: mig create \"<migration name>\"", "command_usage")
 		}
 
 	case "init":
-		err = CommandInit(cfg)
+		res = CommandInit(cfg)
 
 	case "lock":
-		err = CommandLock(cfg)
+		res = CommandLock(cfg)
 
 	case "unlock":
-		err = CommandUnlock(cfg)
+		res = CommandUnlock(cfg)
 
 	case "list":
 		fallthrough
 	case "ls":
-		err = CommandList(cfg)
+		res = CommandList(cfg)
 
 	case "status":
-		err = CommandStatus(cfg)
+		res = CommandStatus(cfg)
 
 	case "up":
-		err = CommandUp(cfg)
+		res = CommandUp(cfg)
 
 	case "down":
-		err = CommandDown(cfg)
+		res = CommandDown(cfg)
 
 	case "all":
-		err = CommandAll(cfg)
+		res = CommandAll(cfg)
 
 	case "upto":
 		if len(subcommands) >= 2 {
-			err = CommandUpto(cfg, subcommands[1])
+			res = CommandUpto(cfg, subcommands[1])
 		} else {
-			err = errors.New("usage: mig upto \"<migration name>\"")
+			res.SetError("usage: mig upto \"<migration name>\"", "command_usage")
 		}
 
 	case "version":
-		err = CommandVersion()
+		res = CommandVersion(cfg)
 
 	default:
-		err = errors.New(fmt.Sprintf("unsupported command %s", subcommands[0]))
+		res.SetError(fmt.Sprintf("unsupported command %s", subcommands[0]), "command_unknown")
 	}
 
-	return err
+	return res
 
 }

--- a/commands/down.go
+++ b/commands/down.go
@@ -1,19 +1,19 @@
 package commands
 
 import (
-	"errors"
+	"fmt"
 
-	"github.com/fatih/color"
 	"github.com/tlhunter/mig/config"
 	"github.com/tlhunter/mig/database"
 	"github.com/tlhunter/mig/migrations"
+	"github.com/tlhunter/mig/result"
 )
 
-func CommandDown(cfg config.MigConfig) error {
+func CommandDown(cfg config.MigConfig) result.Response {
 	dbox, err := database.Connect(cfg.Connection)
 
 	if err != nil {
-		return err
+		return *result.NewErrorWithDetails("database connection error", "db_conn", err)
 	}
 
 	defer dbox.Db.Close()
@@ -21,32 +21,36 @@ func CommandDown(cfg config.MigConfig) error {
 	status, err := migrations.GetStatus(cfg, dbox)
 
 	if err != nil {
-		color.Red("Encountered an error trying to get migrations status!")
-		return err
+		return *result.NewErrorWithDetails("Encountered an error trying to get migrations status!", "retrieve_status", err)
 	}
 
 	last := status.Last
+
+	if last == nil {
+		return *result.NewError("There are no migrations to revert.", "nothing_to_revert")
+	}
 
 	filename := cfg.Migrations + "/" + last.Name
 
 	queries, err := migrations.GetQueriesFromFile(filename)
 
 	if err != nil {
-		color.Red("Error attempting to read last migration file!")
-		color.White("Normally a missing migration file isn't a big deal but it's a no go for migrating down.")
-		color.White("This file is required before continuing. Perhaps it can be pulled from version control?")
-		return err
+		res := *result.NewErrorWithDetails("Error attempting to read last migration file!", "unable_read_migration_file", err)
+
+		res.AddErrorLn("Normally a missing migration file isn't a big deal but it's a no go for migrating down.")
+		res.AddErrorLn("This file is required before continuing. Perhaps it can be pulled from version control?")
+
+		return res
 	}
 
 	locked, err := database.ObtainLock(dbox)
 
 	if err != nil {
-		color.Red("Error obtaining lock for migrating down!")
-		return err
+		return *result.NewErrorWithDetails("Error obtaining lock for migration down!", "obtain_lock", err)
 	}
 
 	if !locked {
-		return errors.New("Unable to obtain lock for migrating down!")
+		return *result.NewError("Unable to obtain lock for migrating down!", "obtain_lock")
 	}
 
 	var query string
@@ -60,30 +64,30 @@ func CommandDown(cfg config.MigConfig) error {
 	_, err = dbox.Db.Exec(query)
 
 	if err != nil {
-		color.Red("Encountered an error while running down migration!")
-		return err
+		return *result.NewErrorWithDetails("Encountered an error while running down migration!", "migration_failed", err)
 	}
 
-	color.Green("Migration down %s was successfully applied!", last.Name)
+	res := result.NewSuccess(fmt.Sprintf("Down migration for %s was successfully applied!", last.Name))
 
 	err = migrations.RemoveMigration(dbox, last.Name, last.Id)
 
 	if err != nil {
-		color.Red("The migration down query executed but unable to track it in the migrations table!")
-		color.White("You may want to manually remove it and investigate the error.")
-		return err
+		res.SetError("The migration down query executed but unable to track it in the migrations table!", "untracked_migration")
+		res.SetErrorDetails(err)
+		res.AddErrorLn("You may want to manually remove it and investigate the error.")
+		return *res
 	}
 
 	released, err := database.ReleaseLock(dbox)
 
 	if err != nil {
-		color.Red("Error obtaining lock for down migration!")
-		return err
+		res.SetError("Error obtaining lock for down migration!", "release_lock")
+		return *res
 	}
 
 	if !released {
-		return errors.New("Unable to obtain lock for down migration!")
+		res.SetError("Unable to obtain lock for down migration!", "release_lock")
 	}
 
-	return nil
+	return *res
 }

--- a/commands/init.go
+++ b/commands/init.go
@@ -1,9 +1,9 @@
 package commands
 
 import (
-	"github.com/fatih/color"
 	"github.com/tlhunter/mig/config"
 	"github.com/tlhunter/mig/database"
+	"github.com/tlhunter/mig/result"
 )
 
 var (
@@ -35,11 +35,11 @@ INSERT INTO migrations_lock SET ` + "`index`" + ` = 1, is_locked = 0;`,
 	}
 )
 
-func CommandInit(cfg config.MigConfig) error {
+func CommandInit(cfg config.MigConfig) result.Response {
 	dbox, err := database.Connect(cfg.Connection)
 
 	if err != nil {
-		return err
+		return *result.NewErrorWithDetails("database connection error", "db_conn", err)
 	}
 
 	defer dbox.Db.Close()
@@ -47,11 +47,8 @@ func CommandInit(cfg config.MigConfig) error {
 	_, err = dbox.Exec(INIT)
 
 	if err != nil {
-		color.Red("error initializing mig!")
-		return err
+		return *result.NewErrorWithDetails("error initializing mig!", "unable_init", err)
 	}
 
-	color.Green("successfully initialized mig.")
-
-	return nil
+	return *result.NewSuccess("successfully initialized mig")
 }

--- a/commands/list.go
+++ b/commands/list.go
@@ -42,14 +42,14 @@ func CommandList(cfg config.MigConfig) result.Response {
 
 	if status.Missing > 0 || status.Skipped > 0 {
 		res.AddSuccessLn("")
-	}
 
-	if status.Skipped > 0 {
-		res.AddSuccessLn(color.RedString("* A skipped migration was encountered. If editing locally you may need to rename the file to the current time."))
-	}
+		if status.Skipped > 0 {
+			res.AddSuccessLn(color.RedString("* A skipped migration was encountered. If editing locally you may need to rename the file to the current time."))
+		}
 
-	if status.Missing > 0 {
-		res.AddSuccessLn(color.YellowString("* A missing migration was encountered. You might need to pull changes from repo."))
+		if status.Missing > 0 {
+			res.AddSuccessLn(color.YellowString("* A missing migration was encountered. You might need to pull changes from repo."))
+		}
 	}
 
 	res.AddSuccessLn(color.HiWhiteString("Applied: %d, Unapplied: %d, Skipped: %d, Missing: %d", status.Applied, status.Unapplied, status.Skipped, status.Missing))

--- a/commands/locks.go
+++ b/commands/locks.go
@@ -1,9 +1,9 @@
 package commands
 
 import (
-	"github.com/fatih/color"
 	"github.com/tlhunter/mig/config"
 	"github.com/tlhunter/mig/database"
+	"github.com/tlhunter/mig/result"
 )
 
 var (
@@ -23,11 +23,11 @@ COMMIT;`,
 	}
 )
 
-func CommandLock(cfg config.MigConfig) error {
+func CommandLock(cfg config.MigConfig) result.Response {
 	dbox, err := database.Connect(cfg.Connection)
 
 	if err != nil {
-		return err
+		return *result.NewErrorWithDetails("database connection error", "db_conn", err)
 	}
 
 	defer dbox.Db.Close()
@@ -36,25 +36,21 @@ func CommandLock(cfg config.MigConfig) error {
 	err = dbox.QueryRow(LOCK).Scan(&was_locked)
 
 	if err != nil {
-		color.Red("mig: unable to lock!")
-		return err
+		return *result.NewErrorWithDetails("unable to lock!", "unable_lock", err)
 	}
 
 	if was_locked == 0 {
-		color.Green("mig: successfully locked.")
-		return nil
+		return *result.NewSuccess("successfully locked.")
 	}
 
-	color.Yellow("mig: already locked!")
-
-	return nil
+	return *result.NewSuccess("already locked!") // TODO: yellow
 }
 
-func CommandUnlock(cfg config.MigConfig) error {
+func CommandUnlock(cfg config.MigConfig) result.Response {
 	dbox, err := database.Connect(cfg.Connection)
 
 	if err != nil {
-		return err
+		return *result.NewErrorWithDetails("database connection error", "db_conn", err)
 	}
 
 	defer dbox.Db.Close()
@@ -63,16 +59,12 @@ func CommandUnlock(cfg config.MigConfig) error {
 	err = dbox.QueryRow(UNLOCK).Scan(&was_locked)
 
 	if err != nil {
-		color.Red("mig: unable to unlock!")
-		return err
+		return *result.NewErrorWithDetails("unable to unlock!", "unable_unlock", err)
 	}
 
 	if was_locked == 1 {
-		color.Green("mig: successfully unlocked.")
-		return nil
+		return *result.NewSuccess("successfully unlocked.")
 	}
 
-	color.Yellow("mig: already unlocked!")
-
-	return nil
+	return *result.NewSuccess("already unlocked!") // TODO: yellow
 }

--- a/commands/up.go
+++ b/commands/up.go
@@ -23,6 +23,11 @@ type MigrationName struct {
 	Migration string `json:"migration"`
 }
 
+type CommandUpResult struct {
+	MigrationBatch int                      `json:"batch"`
+	Migration      *migrations.MigrationRow `json:"migration"`
+}
+
 func CommandUp(cfg config.MigConfig) result.Response {
 	dbox, err := database.Connect(cfg.Connection)
 
@@ -88,9 +93,9 @@ func CommandUp(cfg config.MigConfig) result.Response {
 		return *res
 	}
 
-	res := result.NewSerializable(color.GreenString("Migration %s was successfully applied!", next), CommandUpFamilyResult{
+	res := result.NewSerializable(color.GreenString("Migration %s was successfully applied!", next), CommandUpResult{
 		MigrationBatch: migration.Batch,
-		Migrations:     &[]migrations.MigrationRow{migration},
+		Migration:      &migration,
 	})
 
 	released, err := database.ReleaseLock(dbox)

--- a/commands/up.go
+++ b/commands/up.go
@@ -1,7 +1,8 @@
 package commands
 
 import (
-	"github.com/fatih/color"
+	"fmt"
+
 	"github.com/tlhunter/mig/config"
 	"github.com/tlhunter/mig/database"
 	"github.com/tlhunter/mig/migrations"
@@ -93,7 +94,7 @@ func CommandUp(cfg config.MigConfig) result.Response {
 		return *res
 	}
 
-	res := result.NewSerializable(color.GreenString("Migration %s was successfully applied!", next), CommandUpResult{
+	res := result.NewSerializable(fmt.Sprintf("Migration %s was successfully applied!", next), CommandUpResult{
 		MigrationBatch: migration.Batch,
 		Migration:      &migration,
 	})

--- a/commands/up.go
+++ b/commands/up.go
@@ -1,12 +1,11 @@
 package commands
 
 import (
-	"errors"
-
 	"github.com/fatih/color"
 	"github.com/tlhunter/mig/config"
 	"github.com/tlhunter/mig/database"
 	"github.com/tlhunter/mig/migrations"
+	"github.com/tlhunter/mig/result"
 )
 
 var (
@@ -20,11 +19,15 @@ var (
 	}
 )
 
-func CommandUp(cfg config.MigConfig) error {
+type MigrationName struct {
+	Migration string `json:"migration"`
+}
+
+func CommandUp(cfg config.MigConfig) result.Response {
 	dbox, err := database.Connect(cfg.Connection)
 
 	if err != nil {
-		return err
+		return *result.NewErrorWithDetails("database connection error", "db_conn", err)
 	}
 
 	defer dbox.Db.Close()
@@ -32,18 +35,17 @@ func CommandUp(cfg config.MigConfig) error {
 	status, err := migrations.GetStatus(cfg, dbox)
 
 	if err != nil {
-		color.Red("Encountered an error trying to get migrations status!")
-		return err
+		return *result.NewErrorWithDetails("Encountered an error trying to get migrations status!", "retrieve_status", err)
 	}
 
 	if status.Skipped > 0 {
-		return errors.New("Refusing to run with skipped migrations! Run `mig status` for details.")
+		return *result.NewError("Refusing to run with skipped migrations! Run `mig status` for details.", "abort_skipped_migrations")
 	}
 
 	next := status.Next
 
 	if next == "" {
-		return errors.New("There are no migrations to run.")
+		return *result.NewError("There are no migrations to run.", "no_migrations")
 	}
 
 	filename := cfg.Migrations + "/" + next
@@ -51,19 +53,17 @@ func CommandUp(cfg config.MigConfig) error {
 	queries, err := migrations.GetQueriesFromFile(filename)
 
 	if err != nil {
-		color.Red("Error attempting to read next migration file!")
-		return err
+		return *result.NewErrorWithDetails("Error attempting to read next migration file!", "read_next_migration", err)
 	}
 
 	locked, err := database.ObtainLock(dbox)
 
 	if err != nil {
-		color.Red("Error obtaining lock for migration!")
-		return err
+		return *result.NewErrorWithDetails("Error obtaining lock for migration!", "obtain_lock", err)
 	}
 
 	if !locked {
-		return errors.New("Unable to obtain lock for migration!")
+		return *result.NewError("Unable to obtain lock for migration!", "obtain_lock")
 	}
 
 	var query string
@@ -77,30 +77,32 @@ func CommandUp(cfg config.MigConfig) error {
 	_, err = dbox.Db.Exec(query)
 
 	if err != nil {
-		color.Red("Encountered an error while running migration!")
-		return err
+		return *result.NewErrorWithDetails("Encountered an error while running migration!", "migration_failed", err)
 	}
 
-	color.Green("Migration %s was successfully applied!", next)
-
-	err = migrations.AddMigration(dbox, next)
+	migration, err := migrations.AddMigration(dbox, next)
 
 	if err != nil {
-		color.Red("The migration query executed but unable to track it in the migrations table!")
-		color.White("You may want to manually add it and investigate the error.")
-		return err
+		res := result.NewErrorWithDetails("The migration query executed but unable to track it in the migrations table!", "untracked_migration", err)
+		res.AddErrorLn("You may want to manually add it and investigate the error.")
+		return *res
 	}
+
+	res := result.NewSerializable(color.GreenString("Migration %s was successfully applied!", next), CommandUpFamilyResult{
+		MigrationBatch: migration.Batch,
+		Migrations:     &[]migrations.MigrationRow{migration},
+	})
 
 	released, err := database.ReleaseLock(dbox)
 
 	if err != nil {
-		color.Red("Error obtaining lock for migration!")
-		return err
+		res.SetError("Error releasing lock after running migration!", "release_lock")
+		return *res
 	}
 
 	if !released {
-		return errors.New("Unable to obtain lock for migration!")
+		res.SetError("Unable to release lock after running migration!", "release_lock")
 	}
 
-	return nil
+	return *res
 }

--- a/commands/upto.go
+++ b/commands/upto.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/fatih/color"
@@ -9,17 +8,22 @@ import (
 	"github.com/tlhunter/mig/config"
 	"github.com/tlhunter/mig/database"
 	"github.com/tlhunter/mig/migrations"
+	"github.com/tlhunter/mig/result"
 )
+
+type CommandUptoResult struct {
+	History []migrations.MigrationRowStatus `json:"history"`
+}
 
 // TODO: DRY up the common code between up, upto, all, and down
 // TODO: This requires exact match "TIME_foo.sql"
 //       would be nice to support "TIME_foo" or "foo" if unambiguous
 
-func CommandUpto(cfg config.MigConfig, target string) error {
+func CommandUpto(cfg config.MigConfig, target string) result.Response {
 	dbox, err := database.Connect(cfg.Connection)
 
 	if err != nil {
-		return err
+		return *result.NewErrorWithDetails("database connection error", "db_conn", err)
 	}
 
 	defer dbox.Db.Close()
@@ -28,21 +32,20 @@ func CommandUpto(cfg config.MigConfig, target string) error {
 	status, err := migrations.GetStatus(cfg, dbox)
 
 	if err != nil {
-		color.Red("Encountered an error trying to get migrations status!")
-		return err
+		return *result.NewErrorWithDetails("Encountered an error trying to get migrations status!", "retrieve_status", err)
 	}
 
 	if status.Skipped > 0 {
-		return errors.New("Refusing to run with skipped migrations! Run `mig status` for details.")
+		return *result.NewError("Refusing to run with skipped migrations! Run `mig status` for details.", "abort_skipped_migrations")
 	}
 
 	if status.Next == "" {
-		return errors.New("There are no migrations to run.")
+		return *result.NewError("There are no migrations to run.", "no_migrations")
 	}
 
 	// ensure that the target is unapplied and ahead of current
 	reachedCandidates := false
-	if status.Last.Name == "" {
+	if status.Last == nil || status.Last.Name == "" {
 		// if no migrations were run then any migration is fair game
 		reachedCandidates = true
 	}
@@ -63,24 +66,29 @@ func CommandUpto(cfg config.MigConfig, target string) error {
 	}
 
 	if !targetIsCandidate {
-		return errors.New(fmt.Sprintf("Unable to find an unexecuted upcoming migration named %s", target))
+		// TODO: The name of the migration should be a JSON field
+		return *result.NewError(fmt.Sprintf("Unable to find an unexecuted upcoming migration named %s", target), "cannot_find_migration")
 	}
 
 	locked, err := database.ObtainLock(dbox)
 
 	if err != nil {
-		color.Red("Error obtaining lock for running migrations!")
-		return err
+		return *result.NewErrorWithDetails("Error obtaining lock for migration!", "obtain_lock", err)
 	}
 
 	if !locked {
-		return errors.New("Unable to obtain lock for running migrations!")
+		return *result.NewError("Unable to obtain lock for migration!", "obtain_lock")
 	}
 
 	highest, err := migrations.GetHighestValues(dbox)
 	batchId := highest.Batch
 
-	color.HiWhite("Running migrations for batch %d...", batchId)
+	var executedMigrations []migrations.MigrationRow
+
+	res := result.NewSerializable(color.HiWhiteString("Running migrations for batch %d...", batchId), CommandUpFamilyResult{
+		MigrationBatch: batchId,
+		Migrations:     &executedMigrations,
+	})
 
 	for {
 		status, err := migrations.GetStatus(cfg, dbox)
@@ -96,8 +104,8 @@ func CommandUpto(cfg config.MigConfig, target string) error {
 		queries, err := migrations.GetQueriesFromFile(filename)
 
 		if err != nil {
-			color.Red("Error attempting to read next migration file!")
-			return err
+			// TODO: Should tell user the `filename`
+			return *result.NewErrorWithDetails("Error attempting to read next migration file!", "read_next_migration", err)
 		}
 
 		var query string
@@ -111,20 +119,21 @@ func CommandUpto(cfg config.MigConfig, target string) error {
 		_, err = dbox.Db.Exec(query)
 
 		if err != nil {
-			color.Red("Encountered an error while running migration!")
-			return err
+			return *result.NewErrorWithDetails("Encountered an error while running migration!", "migration_failed", err)
 		}
 
-		color.Green("Migration %s was successfully applied!", next)
+		res.AddSuccessLn(color.GreenString("Migration %s was successfully applied!", next))
 
-		err = migrations.AddMigrationWithBatch(dbox, next, batchId)
+		migration, err := migrations.AddMigrationWithBatch(dbox, next, batchId)
 
 		if err != nil {
-			color.Red("The migration query executed but unable to track it in the migrations table!")
-			color.White("You may want to manually add it and investigate the error.")
-			color.White("Any remaining migrations will not be executed!")
-			return err
+			res.SetError("The migration query executed but unable to track it in the migrations table!", "untracked_migration")
+			res.AddErrorLn("You may want to manually add it and investigate the error.")
+			res.AddErrorLn("Any remaining migrations will not be executed!")
+			return *res
 		}
+
+		executedMigrations = append(executedMigrations, migration)
 
 		if next == target {
 			break
@@ -134,13 +143,13 @@ func CommandUpto(cfg config.MigConfig, target string) error {
 	released, err := database.ReleaseLock(dbox)
 
 	if err != nil {
-		color.Red("Error releasing lock for migration!")
-		return err
+		res.SetError("Error releasing lock after running migration!", "release_lock")
+		return *res
 	}
 
 	if !released {
-		return errors.New("Unable to release lock for migration!")
+		res.SetError("Unable to release lock after running migration!", "release_lock")
 	}
 
-	return nil
+	return *res
 }

--- a/commands/version.go
+++ b/commands/version.go
@@ -2,14 +2,27 @@ package commands
 
 import (
 	"github.com/fatih/color"
+	"github.com/tlhunter/mig/config"
+	"github.com/tlhunter/mig/result"
 )
 
 var Version string   // set at compile time
 var BuildTime string // set at compile time
 
-func CommandVersion() error {
-	color.Green("mig version: " + Version)
-	color.White("build time:  " + BuildTime)
+type CommandVersionResult struct {
+	Version   string `json:"version"`
+	BuildTime string `json:"build_time"`
+}
 
-	return nil
+func CommandVersion(cfg config.MigConfig) result.Response {
+	data := CommandVersionResult{
+		Version:   Version,
+		BuildTime: BuildTime,
+	}
+
+	res := result.NewSerializable(color.GreenString("mig version: "+Version), data)
+
+	res.AddSuccessLn(color.WhiteString("build time:  " + BuildTime))
+
+	return *res
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,8 @@
 package config
 
-import "errors"
+import (
+	"errors"
+)
 
 const (
 	DEF_MIG_DIR = "./migrations"
@@ -10,12 +12,15 @@ type MigConfig struct {
 	Connection string // DB connection string
 	Migrations string // migrations directory, e.g. ./migrations
 	MigRcPath  string // override path to config file
+	OutputJson bool   // stdout should be valid JSON
 }
 
 func GetConfig() (MigConfig, []string, error) {
 	config := MigConfig{}
 
 	flagConfig, subcommands, _ := GetConfigFromProcessFlags()
+
+	config.OutputJson = flagConfig.OutputJson
 
 	err := SetEnvFromConfigFile(flagConfig.MigRcPath) // reads .env and sets env vars but does not override
 

--- a/config/flags.go
+++ b/config/flags.go
@@ -11,6 +11,7 @@ func GetConfigFromProcessFlags() (MigConfig, []string, error) {
 	connection := opt.String("connection", "")
 	migrations := opt.String("migrations", "")
 	migRcPath := opt.String("file", "")
+	outputJson := opt.Bool("json", false)
 
 	subcommand, err := opt.Parse(os.Args[1:])
 
@@ -18,6 +19,7 @@ func GetConfigFromProcessFlags() (MigConfig, []string, error) {
 		Connection: *connection,
 		Migrations: *migrations,
 		MigRcPath:  *migRcPath,
+		OutputJson: *outputJson,
 	}
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -3,24 +3,22 @@ package main
 import (
 	"os"
 
-	"github.com/fatih/color"
 	"github.com/tlhunter/mig/commands"
 	"github.com/tlhunter/mig/config"
+	"github.com/tlhunter/mig/result"
 )
 
 func main() {
 	cfg, subcommands, err := config.GetConfig()
 
+	var res result.Response
+
 	if err != nil && len(subcommands) == 1 && subcommands[0] == "version" {
-		err = commands.CommandVersion()
-	} else if err != nil {
-		color.Red("unable to parse configuration")
-	} else {
-		err = commands.Dispatch(cfg, subcommands)
+		res = commands.CommandVersion(cfg)
+	} else if err == nil {
+		res = commands.Dispatch(cfg, subcommands)
 	}
 
-	if err != nil {
-		os.Stderr.WriteString(color.RedString(err.Error()) + "\n")
-		os.Exit(1)
-	}
+	res.Display(cfg.OutputJson)
+	os.Exit(int(res.ExitStatus))
 }

--- a/migrations/listrows.go
+++ b/migrations/listrows.go
@@ -12,10 +12,10 @@ var LIST = database.QueryBox{
 }
 
 type MigrationRow struct {
-	Id    int
-	Name  string
-	Batch int
-	Time  time.Time
+	Id    int        `json:"id,omitempty"`
+	Name  string     `json:"name"`
+	Batch int        `json:"batch,omitempty"`
+	Time  *time.Time `json:"time,omitempty"`
 }
 
 func ListRows(dbox database.DbBox) ([]MigrationRow, error) {
@@ -44,7 +44,7 @@ func ListRows(dbox database.DbBox) ([]MigrationRow, error) {
 			Id:    id,
 			Name:  name,
 			Batch: batch,
-			Time:  time,
+			Time:  &time,
 		})
 	}
 

--- a/migrations/status.go
+++ b/migrations/status.go
@@ -6,18 +6,18 @@ import (
 )
 
 type MigrationStatus struct {
-	Skipped   int          // number of skipped migrations
-	Missing   int          // number of locally missing file migrations
-	Last      MigrationRow // last successfully executed migration
-	Next      string       // the next migration to execute
-	Applied   int
-	Unapplied int
-	History   []MigrationRowStatus
+	Applied   int                  `json:"applied"`
+	Unapplied int                  `json:"unapplied"`
+	Skipped   int                  `json:"skipped"`        // number of skipped migrations
+	Missing   int                  `json:"missing"`        // number of locally missing file migrations
+	Last      *MigrationRow        `json:"last,omitempty"` // last successfully executed migration
+	Next      string               `json:"next"`           // the next migration to execute
+	History   []MigrationRowStatus `json:"history,omitempty"`
 }
 
 type MigrationRowStatus struct {
-	Migration MigrationRow
-	Status    string
+	Migration MigrationRow `json:"migration"`
+	Status    string       `json:"status"`
 }
 
 func GetStatus(cfg config.MigConfig, dbox database.DbBox) (MigrationStatus, error) {
@@ -53,7 +53,7 @@ func GetStatus(cfg config.MigConfig, dbox database.DbBox) (MigrationStatus, erro
 
 		if migFile == migRow.Name {
 			// This migration is present both on disk and in the database
-			status.Last = migRow
+			status.Last = &migRow
 			mfi++
 			mri++
 			status.Applied++
@@ -92,7 +92,7 @@ func GetStatus(cfg config.MigConfig, dbox database.DbBox) (MigrationStatus, erro
 		// There are still rows in the database to print
 		for i := mri; i < len(migRows); i++ {
 			migRow := migRows[i]
-			status.Last = migRow
+			status.Last = &migRow
 			status.Applied++
 			status.History = append(status.History, MigrationRowStatus{
 				Migration: migRow,

--- a/result/result.go
+++ b/result/result.go
@@ -1,0 +1,128 @@
+package result
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/fatih/color"
+)
+
+func NewError(err string, code string) *Response {
+	return &Response{
+		ExitStatus: 1,
+		Error:      err,
+		ErrorCode:  code,
+	}
+}
+
+func NewErrorWithDetails(err string, code string, details error) *Response {
+	detailsString := ""
+
+	if details != nil {
+		detailsString = details.Error()
+	}
+
+	return &Response{
+		ExitStatus: 1,
+		Error:      err,
+		ErrorCode:  code,
+		Details:    detailsString,
+	}
+}
+
+func NewSuccess(success string) *Response {
+	return &Response{
+		ExitStatus: 0,
+		Success:    success,
+	}
+}
+
+func NewSerializable(success string, serializable any) *Response {
+	return &Response{
+		ExitStatus:   0,
+		Success:      success,
+		Serializable: serializable,
+	}
+}
+
+// Returned by command functions
+type Response struct {
+	Error     string `json:"error,omitempty"`         // hand written error message
+	Details   string `json:"error_details,omitempty"` // underlying error message
+	ErrorCode string `json:"code,omitempty"`          // machine-keyable error code
+	Success   string `json:"success,omitempty"`       // hand written success message
+
+	Serializable any   `json:"-"` // wholesale output if mode is JSON
+	ExitStatus   uint8 `json:"-"` // process exit status code. keeping hidden since it's not always present
+
+	SuccessMultiline bool `json:"-"` // success message is multi-line, disable automatic colors
+	ErrorMultiline   bool `json:"-"` // error message is multi-line, disable automatic colors
+}
+
+func (r *Response) AddSuccessLn(line string) {
+	r.Success += "\n" + line
+	r.SuccessMultiline = true
+}
+
+func (r *Response) AddErrorLn(line string) {
+	r.Error += "\n" + line
+	r.ErrorMultiline = true
+}
+
+func (r *Response) SetError(err string, code string) {
+	r.ExitStatus = 1
+	r.Error = err
+	r.ErrorCode = code
+}
+
+func (r *Response) SetErrorDetails(details error) {
+	r.ExitStatus = 1
+	r.Details = details.Error()
+}
+
+func (r Response) Display(encode bool) error {
+	if encode {
+		if r.Serializable != nil {
+			serialized, err := json.Marshal(r.Serializable)
+
+			if err != nil {
+				fmt.Println("unable to serialize custom output json")
+				return err
+			}
+
+			fmt.Println(string(serialized))
+		} else {
+			serialized, err := json.Marshal(r)
+
+			if err != nil {
+				fmt.Println("unable to serialize response output json")
+				return err
+			}
+
+			fmt.Println(string(serialized))
+		}
+	} else {
+		if r.Error != "" {
+			if r.ErrorMultiline {
+				fmt.Println(r.Error)
+			} else {
+				color.Red(r.Error)
+			}
+		}
+
+		if r.Details != "" {
+			color.Yellow(r.Details)
+		}
+
+		if r.Success != "" {
+
+			if r.ErrorMultiline {
+				fmt.Println(r.Success)
+			} else {
+				color.HiGreen(r.Success)
+			}
+		}
+	}
+
+	return nil
+}

--- a/result/result.go
+++ b/result/result.go
@@ -3,6 +3,7 @@ package result
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/fatih/color"
 )
@@ -60,12 +61,24 @@ type Response struct {
 }
 
 func (r *Response) AddSuccessLn(line string) {
-	r.Success += "\n" + line
+	// when switching from single to multi line, assuming we already have content, add a newline
+	if !r.SuccessMultiline && r.Success != "" {
+		r.Success += "\n"
+	}
+
+	r.Success += line + "\n"
+
 	r.SuccessMultiline = true
 }
 
 func (r *Response) AddErrorLn(line string) {
-	r.Error += "\n" + line
+	// when switching from single to multi line, assuming we already have content, add a newline
+	if !r.ErrorMultiline && r.Error != "" {
+		r.Error += "\n"
+	}
+
+	r.Error += line + "\n"
+
 	r.ErrorMultiline = true
 }
 
@@ -104,22 +117,22 @@ func (r Response) Display(encode bool) error {
 	} else {
 		if r.Error != "" {
 			if r.ErrorMultiline {
-				fmt.Println(r.Error)
+				fmt.Println(strings.TrimSuffix(r.Error, "\n"))
 			} else {
-				color.Red(r.Error)
+				color.Red(strings.TrimSuffix(r.Error, "\n"))
 			}
 		}
 
 		if r.Details != "" {
-			color.Yellow(r.Details)
+			color.Yellow(strings.TrimSuffix(r.Details, "\n"))
 		}
 
 		if r.Success != "" {
 
 			if r.ErrorMultiline {
-				fmt.Println(r.Success)
+				fmt.Println(strings.TrimSuffix(r.Success, "\n"))
 			} else {
-				color.HiGreen(r.Success)
+				color.HiGreen(strings.TrimSuffix(r.Success, "\n"))
 			}
 		}
 	}


### PR DESCRIPTION
- adds support for `--json` flag
- command functions now return a `result.Response` instance
- commands no longer write output to stdout, instead they write to the response instance
- a generic JSON document is created unless a custom one is set
- fixes #11 

### `mig list` vs `mig list --json`

![Screenshot_20230205_193219](https://user-images.githubusercontent.com/551402/216878103-06802561-5949-4892-b810-c64056dacdf1.png)
