### PR TITLE
big QueryBox refactor, switch to sql.Tx

### DIFF
--- a/commands/all.go
+++ b/commands/all.go
@@ -75,15 +75,7 @@ func CommandAll(cfg config.MigConfig) result.Response {
 			return *result.NewErrorWithDetails("Error attempting to read next migration file!", "read_next_migration", err)
 		}
 
-		var query string
-
-		if queries.UpTx {
-			query = BEGIN.For(dbox.Type) + queries.Up + END.For(dbox.Type)
-		} else {
-			query = queries.Up
-		}
-
-		_, err = dbox.Db.Exec(query)
+		err = dbox.ExecMaybeTx(queries.Up, queries.UpTx)
 
 		if err != nil {
 			return *result.NewErrorWithDetails("Encountered an error while running migration!", "migration_failed", err)

--- a/commands/all.go
+++ b/commands/all.go
@@ -16,7 +16,6 @@ type CommandUpFamilyResult struct {
 
 func CommandAll(cfg config.MigConfig) result.Response {
 	dbox, err := database.Connect(cfg.Connection)
-
 	if err != nil {
 		return *result.NewErrorWithDetails("database connection error", "db_conn", err)
 	}
@@ -25,25 +24,20 @@ func CommandAll(cfg config.MigConfig) result.Response {
 
 	// First call to GetStatus is mostly unused. if it fails then don't continue.
 	status, err := migrations.GetStatus(cfg, dbox)
-
 	if err != nil {
 		return *result.NewErrorWithDetails("Encountered an error trying to get migrations status!", "retrieve_status", err)
 	}
-
 	if status.Skipped > 0 {
 		return *result.NewError("Refusing to run with skipped migrations! Run `mig status` for details.", "abort_skipped_migrations")
 	}
-
 	if status.Next == "" {
 		return *result.NewError("There are no migrations to run.", "no_migrations")
 	}
 
 	locked, err := database.ObtainLock(dbox)
-
 	if err != nil {
 		return *result.NewErrorWithDetails("Error obtaining lock for migration!", "obtain_lock", err)
 	}
-
 	if !locked {
 		return *result.NewError("Unable to obtain lock for migration!", "obtain_lock")
 	}
@@ -60,9 +54,11 @@ func CommandAll(cfg config.MigConfig) result.Response {
 
 	for {
 		status, err := migrations.GetStatus(cfg, dbox)
+		if err != nil {
+			return *result.NewErrorWithDetails("Encountered an error trying to get migrations status!", "retrieve_status", err)
+		}
 
 		next := status.Next
-
 		if next == "" {
 			break
 		}
@@ -70,13 +66,11 @@ func CommandAll(cfg config.MigConfig) result.Response {
 		filename := cfg.Migrations + "/" + next
 
 		queries, err := migrations.GetQueriesFromFile(filename)
-
 		if err != nil {
 			return *result.NewErrorWithDetails("Error attempting to read next migration file!", "read_next_migration", err)
 		}
 
 		err = dbox.ExecMaybeTx(queries.Up, queries.UpTx)
-
 		if err != nil {
 			return *result.NewErrorWithDetails("Encountered an error while running migration!", "migration_failed", err)
 		}
@@ -84,7 +78,6 @@ func CommandAll(cfg config.MigConfig) result.Response {
 		res.AddSuccessLn(color.GreenString("Migration %s was successfully applied!", next))
 
 		migration, err := migrations.AddMigrationWithBatch(dbox, next, batchId)
-
 		if err != nil {
 			res.SetError("The migration query executed but unable to track it in the migrations table!", "untracked_migration")
 			res.SetErrorDetails(err)
@@ -97,12 +90,10 @@ func CommandAll(cfg config.MigConfig) result.Response {
 	}
 
 	released, err := database.ReleaseLock(dbox)
-
 	if err != nil {
 		res.SetError("Error releasing lock after running migration!", "release_lock")
 		return *res
 	}
-
 	if !released {
 		res.SetError("Unable to release lock after running migration!", "release_lock")
 	}

--- a/commands/down.go
+++ b/commands/down.go
@@ -11,7 +11,6 @@ import (
 
 func CommandDown(cfg config.MigConfig) result.Response {
 	dbox, err := database.Connect(cfg.Connection)
-
 	if err != nil {
 		return *result.NewErrorWithDetails("database connection error", "db_conn", err)
 	}
@@ -19,13 +18,11 @@ func CommandDown(cfg config.MigConfig) result.Response {
 	defer dbox.Db.Close()
 
 	status, err := migrations.GetStatus(cfg, dbox)
-
 	if err != nil {
 		return *result.NewErrorWithDetails("Encountered an error trying to get migrations status!", "retrieve_status", err)
 	}
 
 	last := status.Last
-
 	if last == nil {
 		return *result.NewError("There are no migrations to revert.", "nothing_to_revert")
 	}
@@ -33,7 +30,6 @@ func CommandDown(cfg config.MigConfig) result.Response {
 	filename := cfg.Migrations + "/" + last.Name
 
 	queries, err := migrations.GetQueriesFromFile(filename)
-
 	if err != nil {
 		res := *result.NewErrorWithDetails("Error attempting to read last migration file!", "unable_read_migration_file", err)
 
@@ -44,17 +40,14 @@ func CommandDown(cfg config.MigConfig) result.Response {
 	}
 
 	locked, err := database.ObtainLock(dbox)
-
 	if err != nil {
 		return *result.NewErrorWithDetails("Error obtaining lock for migration down!", "obtain_lock", err)
 	}
-
 	if !locked {
 		return *result.NewError("Unable to obtain lock for migrating down!", "obtain_lock")
 	}
 
 	err = dbox.ExecMaybeTx(queries.Down, queries.DownTx)
-
 	if err != nil {
 		return *result.NewErrorWithDetails("Encountered an error while running down migration!", "migration_failed", err)
 	}
@@ -62,7 +55,6 @@ func CommandDown(cfg config.MigConfig) result.Response {
 	res := result.NewSuccess(fmt.Sprintf("Down migration for %s was successfully applied!", last.Name))
 
 	err = migrations.RemoveMigration(dbox, last.Name, last.Id)
-
 	if err != nil {
 		res.SetError("The migration down query executed but unable to track it in the migrations table!", "untracked_migration")
 		res.SetErrorDetails(err)
@@ -71,7 +63,6 @@ func CommandDown(cfg config.MigConfig) result.Response {
 	}
 
 	released, err := database.ReleaseLock(dbox)
-
 	if err != nil {
 		res.SetError("Error obtaining lock for down migration!", "release_lock")
 		return *res

--- a/commands/down.go
+++ b/commands/down.go
@@ -53,15 +53,7 @@ func CommandDown(cfg config.MigConfig) result.Response {
 		return *result.NewError("Unable to obtain lock for migrating down!", "obtain_lock")
 	}
 
-	var query string
-
-	if queries.DownTx {
-		query = BEGIN.For(dbox.Type) + queries.Down + END.For(dbox.Type)
-	} else {
-		query = queries.Down
-	}
-
-	_, err = dbox.Db.Exec(query)
+	err = dbox.ExecMaybeTx(queries.Down, queries.DownTx)
 
 	if err != nil {
 		return *result.NewErrorWithDetails("Encountered an error while running down migration!", "migration_failed", err)

--- a/commands/init.go
+++ b/commands/init.go
@@ -6,9 +6,30 @@ import (
 	"github.com/tlhunter/mig/result"
 )
 
-var (
-	INIT = database.QueryBox{
-		Postgres: `CREATE TABLE migrations (
+func CommandInit(cfg config.MigConfig) result.Response {
+	dbox, err := database.Connect(cfg.Connection)
+
+	if err != nil {
+		return *result.NewErrorWithDetails("database connection error", "db_conn", err)
+	}
+
+	defer dbox.Db.Close()
+
+	if dbox.Type == "postgresql" {
+		err = postgresInit(cfg, dbox)
+	} else if dbox.Type == "mysql" {
+		err = mysqlInit(cfg, dbox)
+	}
+
+	if err != nil {
+		return *result.NewErrorWithDetails("error initializing mig!", "unable_init", err)
+	}
+
+	return *result.NewSuccess("successfully initialized mig")
+}
+
+func postgresInit(cfg config.MigConfig, dbox database.DbBox) error {
+	_, err := dbox.Db.Exec(`CREATE TABLE migrations (
 	id serial NOT NULL,
 	name varchar(255) NULL,
 	batch int4 NULL,
@@ -20,8 +41,13 @@ CREATE TABLE migrations_lock (
 	is_locked int4 NULL,
 	CONSTRAINT migrations_lock_pkey PRIMARY KEY (index)
 );
-INSERT INTO migrations_lock ("index", is_locked) VALUES(1, 0);`,
-		Mysql: `CREATE TABLE migrations (
+INSERT INTO migrations_lock ("index", is_locked) VALUES(1, 0);`)
+
+	return err
+}
+
+func mysqlInit(cfg config.MigConfig, dbox database.DbBox) error {
+	_, err := dbox.Db.Exec(`CREATE TABLE migrations (
 	id serial NOT NULL PRIMARY KEY,
 	name varchar(255) NULL,
 	batch int4 NULL,
@@ -31,24 +57,7 @@ CREATE TABLE migrations_lock (
 	` + "`index`" + ` serial NOT NULL PRIMARY KEY,
 	is_locked int4 NULL
 );
-INSERT INTO migrations_lock SET ` + "`index`" + ` = 1, is_locked = 0;`,
-	}
-)
+INSERT INTO migrations_lock SET ` + "`index`" + ` = 1, is_locked = 0;`)
 
-func CommandInit(cfg config.MigConfig) result.Response {
-	dbox, err := database.Connect(cfg.Connection)
-
-	if err != nil {
-		return *result.NewErrorWithDetails("database connection error", "db_conn", err)
-	}
-
-	defer dbox.Db.Close()
-
-	_, err = dbox.Exec(INIT)
-
-	if err != nil {
-		return *result.NewErrorWithDetails("error initializing mig!", "unable_init", err)
-	}
-
-	return *result.NewSuccess("successfully initialized mig")
+	return err
 }

--- a/commands/init.go
+++ b/commands/init.go
@@ -15,10 +15,10 @@ func CommandInit(cfg config.MigConfig) result.Response {
 
 	defer dbox.Db.Close()
 
-	if dbox.Type == "postgresql" {
-		err = postgresInit(cfg, dbox)
-	} else if dbox.Type == "mysql" {
-		err = mysqlInit(cfg, dbox)
+	if dbox.IsPostgres {
+		err = postgresInit(dbox)
+	} else if dbox.IsMysql {
+		err = mysqlInit(dbox)
 	} else {
 		panic("unknown database: " + dbox.Type)
 	}
@@ -30,7 +30,7 @@ func CommandInit(cfg config.MigConfig) result.Response {
 	return *result.NewSuccess("successfully initialized mig")
 }
 
-func postgresInit(cfg config.MigConfig, dbox database.DbBox) error {
+func postgresInit(dbox database.DbBox) error {
 	tx, err := dbox.Db.Begin()
 	if err != nil {
 		return err
@@ -67,10 +67,10 @@ func postgresInit(cfg config.MigConfig, dbox database.DbBox) error {
 		return err
 	}
 
-	return err
+	return nil
 }
 
-func mysqlInit(cfg config.MigConfig, dbox database.DbBox) error {
+func mysqlInit(dbox database.DbBox) error {
 	tx, err := dbox.Db.Begin()
 	if err != nil {
 		return err
@@ -105,5 +105,5 @@ func mysqlInit(cfg config.MigConfig, dbox database.DbBox) error {
 		return err
 	}
 
-	return err
+	return nil
 }

--- a/commands/init.go
+++ b/commands/init.go
@@ -8,7 +8,6 @@ import (
 
 func CommandInit(cfg config.MigConfig) result.Response {
 	dbox, err := database.Connect(cfg.Connection)
-
 	if err != nil {
 		return *result.NewErrorWithDetails("database connection error", "db_conn", err)
 	}

--- a/commands/list.go
+++ b/commands/list.go
@@ -12,7 +12,6 @@ import (
 
 func CommandList(cfg config.MigConfig) result.Response {
 	dbox, err := database.Connect(cfg.Connection)
-
 	if err != nil {
 		return *result.NewErrorWithDetails("database connection error", "db_conn", err)
 	}
@@ -20,7 +19,6 @@ func CommandList(cfg config.MigConfig) result.Response {
 	defer dbox.Db.Close()
 
 	status, err := migrations.GetStatus(cfg, dbox)
-
 	if err != nil {
 		return *result.NewErrorWithDetails("unable to get migration status", "unable_get_status", err)
 	}

--- a/commands/locks.go
+++ b/commands/locks.go
@@ -6,16 +6,6 @@ import (
 	"github.com/tlhunter/mig/result"
 )
 
-var (
-	UNLOCK = database.QueryBox{
-		Postgres: `UPDATE migrations_lock SET is_locked = 0 WHERE index = 1 RETURNING ( SELECT is_locked AS was_locked FROM migrations_lock WHERE index = 1);`,
-		Mysql: `START TRANSACTION;
-	SELECT is_locked AS was_locked FROM migrations_lock WHERE ` + "`index`" + ` = 1;
-	UPDATE migrations_lock SET is_locked = 0 WHERE ` + "`index`" + ` = 1;
-COMMIT;`,
-	}
-)
-
 func CommandLock(cfg config.MigConfig) result.Response {
 	dbox, err := database.Connect(cfg.Connection)
 
@@ -25,12 +15,12 @@ func CommandLock(cfg config.MigConfig) result.Response {
 
 	defer dbox.Db.Close()
 
-	var was_locked bool
+	var wasLocked bool
 
 	if dbox.IsPostgres {
-		was_locked, err = postgresLock(dbox)
+		wasLocked, err = postgresLock(dbox)
 	} else if dbox.IsMysql {
-		was_locked, err = mysqlLock(dbox)
+		wasLocked, err = mysqlLock(dbox)
 	} else {
 		panic("unknown database: " + dbox.Type)
 	}
@@ -39,7 +29,7 @@ func CommandLock(cfg config.MigConfig) result.Response {
 		return *result.NewErrorWithDetails("unable to lock!", "unable_lock", err)
 	}
 
-	if !was_locked {
+	if !wasLocked {
 		return *result.NewSuccess("successfully locked.")
 	}
 
@@ -47,13 +37,13 @@ func CommandLock(cfg config.MigConfig) result.Response {
 }
 
 func postgresLock(dbox database.DbBox) (bool, error) {
-	var was_locked int
-	err := dbox.Db.QueryRow(`UPDATE migrations_lock SET is_locked = 1 WHERE index = 1 RETURNING ( SELECT is_locked AS was_locked FROM migrations_lock WHERE index = 1);`).Scan(&was_locked)
+	var wasLocked int
+	err := dbox.Db.QueryRow("UPDATE migrations_lock SET is_locked = 1 WHERE index = 1 RETURNING ( SELECT is_locked AS was_locked FROM migrations_lock WHERE index = 1);").Scan(&wasLocked)
 	if err != nil {
 		return false, err
 	}
 
-	return was_locked > 0, nil
+	return wasLocked > 0, nil
 }
 
 func mysqlLock(dbox database.DbBox) (bool, error) {
@@ -64,20 +54,20 @@ func mysqlLock(dbox database.DbBox) (bool, error) {
 
 	defer tx.Rollback()
 
-	var was_locked int
+	var wasLocked int
 
-	err = tx.QueryRow(`SELECT is_locked AS was_locked FROM migrations_lock WHERE ` + "`index`" + ` = 1;`).Scan(&was_locked)
+	err = tx.QueryRow("SELECT is_locked AS was_locked FROM migrations_lock WHERE `index` = 1;").Scan(&wasLocked)
 	if err != nil {
 		return false, err
 	}
 
-	_, err = tx.Exec(`UPDATE migrations_lock SET is_locked = 1 WHERE ` + "`index`" + ` = 1;`)
+	_, err = tx.Exec("UPDATE migrations_lock SET is_locked = 1 WHERE `index` = 1;")
 
 	if err = tx.Commit(); err != nil {
 		return false, err
 	}
 
-	return was_locked > 0, nil
+	return wasLocked > 0, nil
 }
 
 func CommandUnlock(cfg config.MigConfig) result.Response {
@@ -89,16 +79,57 @@ func CommandUnlock(cfg config.MigConfig) result.Response {
 
 	defer dbox.Db.Close()
 
-	var was_locked int
-	err = dbox.QueryRow(UNLOCK).Scan(&was_locked)
+	var wasLocked bool
+
+	if dbox.IsPostgres {
+		wasLocked, err = postgresUnlock(dbox)
+	} else if dbox.IsMysql {
+		wasLocked, err = mysqlUnlock(dbox)
+	} else {
+		panic("unknown database: " + dbox.Type)
+	}
 
 	if err != nil {
 		return *result.NewErrorWithDetails("unable to unlock!", "unable_unlock", err)
 	}
 
-	if was_locked == 1 {
+	if wasLocked {
 		return *result.NewSuccess("successfully unlocked.")
 	}
 
 	return *result.NewSuccess("already unlocked!") // TODO: yellow
+}
+
+func postgresUnlock(dbox database.DbBox) (bool, error) {
+	var wasLocked int
+
+	err := dbox.Db.QueryRow("UPDATE migrations_lock SET is_locked = 0 WHERE index = 1 RETURNING ( SELECT is_locked AS was_locked FROM migrations_lock WHERE index = 1);").Scan(&wasLocked)
+	if err != nil {
+		return false, err
+	}
+
+	return wasLocked > 0, nil
+}
+
+func mysqlUnlock(dbox database.DbBox) (bool, error) {
+	tx, err := dbox.Db.Begin()
+	if err != nil {
+		return false, err
+	}
+
+	defer tx.Rollback()
+
+	var wasLocked int
+
+	err = tx.QueryRow("SELECT is_locked AS was_locked FROM migrations_lock WHERE `index` = 1;").Scan(&wasLocked)
+	if err != nil {
+		return false, err
+	}
+
+	_, err = tx.Exec("UPDATE migrations_lock SET is_locked = 0 WHERE `index` = 1;")
+	if err = tx.Commit(); err != nil {
+		return false, err
+	}
+
+	return wasLocked > 0, nil
 }

--- a/commands/status.go
+++ b/commands/status.go
@@ -64,7 +64,6 @@ func CommandStatus(cfg config.MigConfig) result.Response {
 	// Attempt to connect to database
 
 	dbox, err := database.Connect(cfg.Connection)
-
 	if err != nil {
 		return *result.NewErrorWithDetails("database connection error", "db_conn", err)
 	}
@@ -74,7 +73,6 @@ func CommandStatus(cfg config.MigConfig) result.Response {
 	existMigrations := false
 
 	err = dbox.QueryRow(EXIST_MIGRATIONS).Scan(&existMigrations)
-
 	if err != nil {
 		return *result.NewErrorWithDetails("unable to tell if 'migrations' table exists!", "unable_check_migrations", err)
 	}
@@ -82,7 +80,6 @@ func CommandStatus(cfg config.MigConfig) result.Response {
 	existLock := false
 
 	err = dbox.QueryRow(EXIST_LOCK).Scan(&existLock)
-
 	if err != nil {
 		return *result.NewErrorWithDetails("unable to tell if 'migrations_lock' table exists!", "unable_check_migrations_lock", err)
 	}
@@ -126,7 +123,6 @@ func CommandStatus(cfg config.MigConfig) result.Response {
 		res.AddSuccessLn(color.YellowString("migration table description check is currently unimplemented for mysql."))
 	} else {
 		rows, err := dbox.Query(DESCRIBE)
-
 		if err != nil {
 			return *result.NewErrorWithDetails("unable to describe the migration tables!", "unable_describe", err)
 		}
@@ -176,8 +172,8 @@ func CommandStatus(cfg config.MigConfig) result.Response {
 	// Check if locked
 
 	locked := false
-	err = dbox.QueryRow(LOCK_STATUS).Scan(&locked)
 
+	err = dbox.QueryRow(LOCK_STATUS).Scan(&locked)
 	if err != nil {
 		return *result.NewErrorWithDetails("unable to determine lock status!", "unable_determine_lock_status", err)
 	}
@@ -195,6 +191,9 @@ func CommandStatus(cfg config.MigConfig) result.Response {
 	// Display the name of the last run migration
 
 	status, err := migrations.GetStatus(cfg, dbox)
+	if err != nil {
+		return *result.NewErrorWithDetails("Encountered an error trying to get migrations status!", "retrieve_status", err)
+	}
 
 	if cfg.OutputJson {
 		status.History = nil // omit for status command, it's still present for list command
@@ -209,10 +208,6 @@ func CommandStatus(cfg config.MigConfig) result.Response {
 		}
 
 		return *res
-	}
-
-	if err != nil {
-		return *result.NewErrorWithDetails("unable to determine migration status!", "unable_determine_migration_status", err)
 	}
 
 	if status.Last != nil && status.Last.Name != "" {

--- a/commands/upto.go
+++ b/commands/upto.go
@@ -108,15 +108,7 @@ func CommandUpto(cfg config.MigConfig, target string) result.Response {
 			return *result.NewErrorWithDetails("Error attempting to read next migration file!", "read_next_migration", err)
 		}
 
-		var query string
-
-		if queries.UpTx {
-			query = BEGIN.For(dbox.Type) + queries.Up + END.For(dbox.Type)
-		} else {
-			query = queries.Up
-		}
-
-		_, err = dbox.Db.Exec(query)
+		err = dbox.ExecMaybeTx(queries.Up, queries.UpTx)
 
 		if err != nil {
 			return *result.NewErrorWithDetails("Encountered an error while running migration!", "migration_failed", err)

--- a/commands/upto.go
+++ b/commands/upto.go
@@ -21,7 +21,6 @@ type CommandUptoResult struct {
 
 func CommandUpto(cfg config.MigConfig, target string) result.Response {
 	dbox, err := database.Connect(cfg.Connection)
-
 	if err != nil {
 		return *result.NewErrorWithDetails("database connection error", "db_conn", err)
 	}
@@ -30,15 +29,12 @@ func CommandUpto(cfg config.MigConfig, target string) result.Response {
 
 	// First call to GetStatus is mostly unused. if it fails then don't continue.
 	status, err := migrations.GetStatus(cfg, dbox)
-
 	if err != nil {
 		return *result.NewErrorWithDetails("Encountered an error trying to get migrations status!", "retrieve_status", err)
 	}
-
 	if status.Skipped > 0 {
 		return *result.NewError("Refusing to run with skipped migrations! Run `mig status` for details.", "abort_skipped_migrations")
 	}
-
 	if status.Next == "" {
 		return *result.NewError("There are no migrations to run.", "no_migrations")
 	}
@@ -71,16 +67,17 @@ func CommandUpto(cfg config.MigConfig, target string) result.Response {
 	}
 
 	locked, err := database.ObtainLock(dbox)
-
 	if err != nil {
 		return *result.NewErrorWithDetails("Error obtaining lock for migration!", "obtain_lock", err)
 	}
-
 	if !locked {
 		return *result.NewError("Unable to obtain lock for migration!", "obtain_lock")
 	}
 
 	highest, err := migrations.GetHighestValues(dbox)
+	if err != nil {
+		return *result.NewErrorWithDetails("Unable to determine highest migration!", "unable_determine_highest", err)
+	}
 	batchId := highest.Batch
 
 	var executedMigrations []migrations.MigrationRow
@@ -92,9 +89,11 @@ func CommandUpto(cfg config.MigConfig, target string) result.Response {
 
 	for {
 		status, err := migrations.GetStatus(cfg, dbox)
+		if err != nil {
+			return *result.NewErrorWithDetails("Unable to get migration status!", "retrieve_status", err)
+		}
 
 		next := status.Next
-
 		if next == "" {
 			break
 		}
@@ -102,14 +101,12 @@ func CommandUpto(cfg config.MigConfig, target string) result.Response {
 		filename := cfg.Migrations + "/" + next
 
 		queries, err := migrations.GetQueriesFromFile(filename)
-
 		if err != nil {
-			// TODO: Should tell user the `filename`
+			// TODO: Should tell user the `filename` that caused the error
 			return *result.NewErrorWithDetails("Error attempting to read next migration file!", "read_next_migration", err)
 		}
 
 		err = dbox.ExecMaybeTx(queries.Up, queries.UpTx)
-
 		if err != nil {
 			return *result.NewErrorWithDetails("Encountered an error while running migration!", "migration_failed", err)
 		}
@@ -117,7 +114,6 @@ func CommandUpto(cfg config.MigConfig, target string) result.Response {
 		res.AddSuccessLn(color.GreenString("Migration %s was successfully applied!", next))
 
 		migration, err := migrations.AddMigrationWithBatch(dbox, next, batchId)
-
 		if err != nil {
 			res.SetError("The migration query executed but unable to track it in the migrations table!", "untracked_migration")
 			res.AddErrorLn("You may want to manually add it and investigate the error.")
@@ -126,19 +122,16 @@ func CommandUpto(cfg config.MigConfig, target string) result.Response {
 		}
 
 		executedMigrations = append(executedMigrations, migration)
-
 		if next == target {
 			break
 		}
 	}
 
 	released, err := database.ReleaseLock(dbox)
-
 	if err != nil {
 		res.SetError("Error releasing lock after running migration!", "release_lock")
 		return *res
 	}
-
 	if !released {
 		res.SetError("Unable to release lock after running migration!", "release_lock")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -35,7 +35,7 @@ func GetConfig() (MigConfig, []string, error) {
 	} else if envConfig.Connection != "" {
 		config.Connection = envConfig.Connection
 	} else {
-		return config, subcommands, errors.New("unable to determinte server connection")
+		return config, subcommands, errors.New("unable to determine server connection")
 	}
 
 	if flagConfig.Migrations != "" {

--- a/database/connect.go
+++ b/database/connect.go
@@ -12,7 +12,10 @@ import (
 
 type DbBox struct {
 	Db   *sql.DB
-	Type string
+	Type string // TODO: Make this lowercase
+
+	IsPostgres bool // indicates this connection is for PostgreSQL
+	IsMysql    bool // indicates this connection is for MySQL
 }
 
 func (dbox DbBox) GetQuery(qb QueryBox) string {
@@ -55,6 +58,7 @@ func Connect(connection string) (DbBox, error) {
 	}
 
 	if u.Scheme == "postgresql" {
+		dbox.IsPostgres = true
 		tls := "disable"
 
 		if tls_in == "verify" {
@@ -80,6 +84,7 @@ func Connect(connection string) (DbBox, error) {
 			return dbox, errors.New("unable to connect to postgresql database!")
 		}
 	} else if u.Scheme == "mysql" {
+		dbox.IsMysql = true
 		port := "3306"
 		if u.Port() != "" {
 			port = u.Port()

--- a/database/querybox.go
+++ b/database/querybox.go
@@ -2,7 +2,8 @@ package database
 
 import "fmt"
 
-// TODO: Kill QueryBox once refactor is complete
+// QueryBox makes it easy to store multiple queries for different databases.
+// Use it when an operation can always be completed with a single query for each database type.
 type QueryBox struct {
 	Postgres string
 	Mysql    string

--- a/database/querybox.go
+++ b/database/querybox.go
@@ -2,6 +2,7 @@ package database
 
 import "fmt"
 
+// TODO: Kill QueryBox once refactor is complete
 type QueryBox struct {
 	Postgres string
 	Mysql    string

--- a/migrations/fileparser.go
+++ b/migrations/fileparser.go
@@ -44,7 +44,6 @@ func GetQueriesFromFile(filename string) (MigrationPair, error) {
 	state := STATE_START
 
 	file, err := os.Open(filename)
-
 	if err != nil {
 		return pair, err
 	}

--- a/migrations/fileparser_test.go
+++ b/migrations/fileparser_test.go
@@ -9,7 +9,6 @@ import (
 
 func TestGetQueriesFromFile(t *testing.T) {
 	pair, err := GetQueriesFromFile("../tests/postgres/20230101120058_add_users_table.sql")
-
 	if err != nil {
 		t.Log("had an error", err)
 		t.Fail()

--- a/migrations/listfiles.go
+++ b/migrations/listfiles.go
@@ -9,7 +9,6 @@ func ListFiles(directory string) ([]string, error) {
 	var migFiles []string
 
 	files, err := os.ReadDir(directory)
-
 	if err != nil {
 		return migFiles, err
 	}

--- a/migrations/listfiles_test.go
+++ b/migrations/listfiles_test.go
@@ -8,7 +8,6 @@ import (
 
 func TestListFiles(t *testing.T) {
 	files, err := ListFiles("../tests/postgres")
-
 	if err != nil {
 		t.Log("error listing files", err)
 		t.Fail()

--- a/migrations/progress.go
+++ b/migrations/progress.go
@@ -11,10 +11,6 @@ var (
 		Postgres: `SELECT (SELECT batch FROM migrations ORDER BY batch DESC LIMIT 1) AS highest_batch, (SELECT id FROM migrations ORDER BY id DESC LIMIT 1) AS highest_id;`,
 		Mysql:    `SELECT (SELECT batch FROM migrations ORDER BY batch DESC LIMIT 1) AS highest_batch, (SELECT id FROM migrations ORDER BY id DESC LIMIT 1) AS highest_id;`,
 	}
-	ADD = database.QueryBox{
-		Postgres: `INSERT INTO migrations (id, name, batch, migration_time) VALUES ($1, $2, $3, NOW()) RETURNING id, name, batch, migration_time;`,
-		Mysql:    `INSERT INTO migrations (id, name, batch, migration_time) VALUES (?, ?, ?, NOW());`,
-	}
 	ULTIMATE = database.QueryBox{
 		Postgres: `SELECT id, name FROM migrations ORDER BY id DESC LIMIT 1;`,
 		Mysql:    `SELECT id, name FROM migrations ORDER BY id DESC LIMIT 1;`,
@@ -39,23 +35,59 @@ func AddMigration(dbox database.DbBox, migrationName string) (MigrationRow, erro
 	var migration MigrationRow
 
 	highest, err := GetHighestValues(dbox)
+	if err != nil {
+		return migration, err
+	}
+
+	if dbox.IsPostgres {
+		migration, err = postgresAddMigration(dbox, highest.Id, migrationName, highest.Batch)
+	} else if dbox.IsMysql {
+		migration, err = mysqlAddMigration(dbox, highest.Id, migrationName, highest.Batch)
+	} else {
+		panic("unknown database: " + dbox.Type)
+	}
 
 	if err != nil {
 		return migration, err
 	}
 
-	if dbox.Type == "mysql" {
-		// MySQL provides no easy RETURNING equivalent, so we'll fake it and omit the calculated timestamp
-		_, err = dbox.Exec(ADD, highest.Id, migrationName, highest.Batch)
-		migration.Id = highest.Id
-		migration.Name = migrationName
-		migration.Batch = highest.Batch
-		migration.Time = nil
-	} else {
-		err = dbox.QueryRow(ADD, highest.Id, migrationName, highest.Batch).Scan(&migration.Id, &migration.Name, &migration.Batch, &migration.Time)
+	return migration, nil
+}
+
+func postgresAddMigration(dbox database.DbBox, id int, name string, batchId int) (MigrationRow, error) {
+	var migration MigrationRow
+
+	err := dbox.Db.
+		QueryRow(`INSERT INTO migrations (id, name, batch, migration_time) VALUES ($1, $2, $3, NOW()) RETURNING id, name, batch, migration_time;`, id, name, batchId).
+		Scan(&migration.Id, &migration.Name, &migration.Batch, &migration.Time)
+
+	return migration, err
+}
+
+func mysqlAddMigration(dbox database.DbBox, id int, name string, batchId int) (MigrationRow, error) {
+	var migration MigrationRow
+
+	tx, err := dbox.Db.Begin()
+	if err != nil {
+		return migration, err
 	}
 
+	defer tx.Rollback()
+
+	_, err = tx.Exec("INSERT INTO migrations (id, name, batch, migration_time) VALUES (?, ?, ?, NOW());", id, name, batchId)
 	if err != nil {
+		return migration, err
+	}
+
+	// Technically, the only value we need is the time, since that's the only value that the database determins
+	err = tx.
+		QueryRow("SELECT id, name, batch, migration_time FROM migrations WHERE id = ?;", id).
+		Scan(&migration.Id, &migration.Name, &migration.Batch, &migration.Time)
+	if err != nil {
+		return migration, err
+	}
+
+	if err = tx.Commit(); err != nil {
 		return migration, err
 	}
 
@@ -67,21 +99,18 @@ func AddMigrationWithBatch(dbox database.DbBox, migrationName string, batch int)
 	var migration MigrationRow
 
 	highest, err := GetHighestValues(dbox)
-
 	if err != nil {
 		return migration, err
 	}
 
-	if dbox.Type == "mysql" {
-		// MySQL provides no easy RETURNING equivalent, so we'll fake it and omit the calculated timestamp
-		_, err = dbox.Exec(ADD, highest.Id, migrationName, highest.Batch)
-		migration.Id = highest.Id
-		migration.Name = migrationName
-		migration.Batch = batch
-		migration.Time = nil
+	if dbox.IsPostgres {
+		migration, err = postgresAddMigration(dbox, highest.Id, migrationName, batch)
+	} else if dbox.IsMysql {
+		migration, err = mysqlAddMigration(dbox, highest.Id, migrationName, batch)
 	} else {
-		err = dbox.QueryRow(ADD, highest.Id, migrationName, batch).Scan(&migration.Id, &migration.Name, &migration.Batch, &migration.Time)
+		panic("unknown database: " + dbox.Type)
 	}
+
 	if err != nil {
 		return migration, err
 	}
@@ -97,7 +126,6 @@ func RemoveMigration(dbox database.DbBox, migration string, id int) error {
 	var lastName string
 
 	err := dbox.QueryRow(ULTIMATE).Scan(&lastId, &lastName)
-
 	if err != nil {
 		return err
 	}
@@ -107,9 +135,11 @@ func RemoveMigration(dbox database.DbBox, migration string, id int) error {
 	}
 
 	result, err := dbox.Exec(DELETE, id, migration)
+	if err != nil {
+		return err
+	}
 
 	affected, err := result.RowsAffected()
-
 	if err != nil {
 		return err
 	}
@@ -127,7 +157,6 @@ func GetHighestValues(dbox database.DbBox) (BatchAndId, error) {
 	var count int
 
 	err := dbox.QueryRow(COUNT).Scan(&count)
-
 	if err != nil {
 		return highest, err
 	}
@@ -141,7 +170,6 @@ func GetHighestValues(dbox database.DbBox) (BatchAndId, error) {
 	}
 
 	err = dbox.QueryRow(HIGHEST).Scan(&highest.Batch, &highest.Id)
-
 	if err != nil {
 		return highest, err
 	}

--- a/migrations/status.go
+++ b/migrations/status.go
@@ -24,13 +24,11 @@ func GetStatus(cfg config.MigConfig, dbox database.DbBox) (MigrationStatus, erro
 	var status MigrationStatus
 
 	migFiles, err := ListFiles(cfg.Migrations)
-
 	if err != nil {
 		return status, err
 	}
 
 	migRows, err := ListRows(dbox)
-
 	if err != nil {
 		return status, err
 	}

--- a/result/result.go
+++ b/result/result.go
@@ -97,7 +97,6 @@ func (r Response) Display(encode bool) error {
 	if encode {
 		if r.Serializable != nil {
 			serialized, err := json.Marshal(r.Serializable)
-
 			if err != nil {
 				fmt.Println("unable to serialize custom output json")
 				return err
@@ -106,7 +105,6 @@ func (r Response) Display(encode bool) error {
 			fmt.Println(string(serialized))
 		} else {
 			serialized, err := json.Marshal(r)
-
 			if err != nil {
 				fmt.Println("unable to serialize response output json")
 				return err


### PR DESCRIPTION
- the main goal is to make it easy to have RDBMS-specific code branches
- command runner functions handle database connection (if required)
- defer to other functions depending on database-specific functionality
- this pattern keeps related command code together
  - the other way to slice the pie is to keep RDBMS-specific code together (`postgres.go`, `mysql.go`)
  - but, the functionality is so similar, this should help promote code reuse
  - also, don't want a command with one database to change much from another database
- ~once complete `QueryBox` can go away entirely~
  - on second thought it helps keep most code super clean
- the duplicative `if dbox.Type ==` calls isn't the best, and what to do for the `else`?
  - adding `if dbox.IsPostgres` helps, auto completion of methods
  - in the `else` just doing a `panic` since it's essentially unreachable
- fixes #5 