### PR TITLE
no longer silently fail when running unconfigured

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,8 +1,6 @@
 package config
 
-import (
-	"errors"
-)
+import "github.com/tlhunter/mig/result"
 
 const (
 	DEF_MIG_DIR = "./migrations"
@@ -15,7 +13,7 @@ type MigConfig struct {
 	OutputJson bool   // stdout should be valid JSON
 }
 
-func GetConfig() (MigConfig, []string, error) {
+func GetConfig() (MigConfig, []string, *result.Response) {
 	config := MigConfig{}
 
 	flagConfig, subcommands, _ := GetConfigFromProcessFlags()
@@ -25,7 +23,7 @@ func GetConfig() (MigConfig, []string, error) {
 	err := SetEnvFromConfigFile(flagConfig.MigRcPath) // reads .env and sets env vars but does not override
 
 	if err != nil {
-		return config, []string{}, err
+		return config, []string{}, nil
 	}
 
 	envConfig, _ := GetConfigFromEnvVars()
@@ -35,7 +33,7 @@ func GetConfig() (MigConfig, []string, error) {
 	} else if envConfig.Connection != "" {
 		config.Connection = envConfig.Connection
 	} else {
-		return config, subcommands, errors.New("unable to determine server connection")
+		return config, subcommands, result.NewError("unable to determine server connection", "bad_config")
 	}
 
 	if flagConfig.Migrations != "" {

--- a/main.go
+++ b/main.go
@@ -9,15 +9,17 @@ import (
 )
 
 func main() {
-	cfg, subcommands, err := config.GetConfig()
+	cfg, subcommands, bail := config.GetConfig()
 
 	var res result.Response
 
-	if err != nil && len(subcommands) == 0 {
+	if bail != nil && len(subcommands) == 0 {
 		res.SetError("usage: mig <command>", "command_usage")
-	} else if err != nil && len(subcommands) == 1 && subcommands[0] == "version" {
+	} else if bail != nil && len(subcommands) == 1 && subcommands[0] == "version" {
 		res = commands.CommandVersion(cfg)
-	} else if err == nil {
+	} else if bail != nil {
+		res = *bail
+	} else if bail == nil {
 		res = commands.Dispatch(cfg, subcommands)
 	}
 


### PR DESCRIPTION
- when a configuration error happens the process would exit without displaying that anything went wrong
- now the config lookup returns a Result object with more information
- fixes #16
- it's a bit messy now since there are two Result objects available in main